### PR TITLE
feat: merge hero and about with animated highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ The chosen theme is stored in `localStorage` and re-applied on future visits. Yo
 - `?theme=corporate`
 
 To add a new theme, create a CSS file under `css/` that defines variables inside `html[data-theme="YOUR_THEME"] { ... }` and reference it in `index.html`.
+
+## Hero/About section
+
+- The hero and about content are combined into a two-column layout on large screens.
+- Highlight numbers are configured via the `data-count` attributes in `index.html`.
+- Animations respect `prefers-reduced-motion` and can be disabled by setting `data-decor="off"` on the `<html>` tag to remove background decoration.

--- a/css/base.css
+++ b/css/base.css
@@ -22,7 +22,7 @@ h1, h2, h3 {
   font-family: var(--font-heading);
 }
 
-.title, .location, .intro, .advantages li {
+.title, .location, .intro {
   color: var(--text-secondary);
 }
 
@@ -78,6 +78,24 @@ h1, h2, h3 {
   text-decoration: none;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
+  position: relative;
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent1);
+  transition: width 0.3s ease, left 0.3s ease;
+}
+
+.nav-link:hover::after,
+.nav-link:focus::after {
+  width: 100%;
+  left: 0;
 }
 
 .nav-link:hover {
@@ -90,9 +108,86 @@ h1, h2, h3 {
   outline: none;
 }
 
-.hero {
-  text-align: center;
+.navbar.sticky-shadow {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.hero-about {
+  position: relative;
   padding: 4rem 0;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.hero-about.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero-about::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, var(--accent3), transparent 70%);
+  opacity: 0.03;
+  pointer-events: none;
+  z-index: -1;
+}
+
+html[data-decor="off"] .hero-about::before {
+  display: none;
+}
+
+.glow-divider {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent1), var(--accent2));
+  box-shadow: 0 0 8px var(--accent1);
+  opacity: 0.6;
+}
+
+.hero-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-left {
+  text-align: center;
+}
+
+.cta-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.cta-btn {
+  min-width: 170px;
+  text-align: center;
+}
+
+.cta-btn:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0 10px var(--accent1);
+}
+
+.cta-btn:active {
+  transform: translateY(1px);
+  box-shadow: none;
+}
+
+.cta-btn:focus {
+  outline: 2px solid var(--focus-outline);
+  outline-offset: 2px;
 }
 
 .avatar {
@@ -102,36 +197,63 @@ h1, h2, h3 {
   border: 4px solid transparent;
   background: linear-gradient(45deg, var(--accent1), var(--accent2)) border-box;
   margin-bottom: 1rem;
-  animation: spin 20s linear infinite;
 }
 
-@keyframes spin {
-  from { transform: rotate(0); }
-  to { transform: rotate(360deg); }
+.floating {
+  animation: float 6s ease-in-out infinite, glow 6s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 10px var(--accent1); }
+  50% { box-shadow: 0 0 20px var(--accent2); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .avatar { animation: none; }
-}
-
-.about, .projects, .contact {
-  padding: 2rem 0;
-}
-
-.about-container {
-  display: grid;
-  grid-template-columns: 1fr;
-  align-items: center;
-  gap: 2rem;
-}
-
-@media (min-width: 700px) {
-  .about-container {
-    grid-template-columns: 1fr 1fr;
+  .floating {
+    animation: none;
   }
-  .about-left {
-    text-align: center;
-  }
+}
+
+.reveal-item {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.reveal-item.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.highlight .count {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--accent1);
+  margin-right: 0.25rem;
+}
+
+.skill-groups {
+  margin-top: 1rem;
+}
+
+.skill-group {
+  margin-bottom: 1rem;
+}
+
+.skill-group h3 {
+  margin-bottom: 0.5rem;
 }
 
 .skills {
@@ -140,24 +262,71 @@ h1, h2, h3 {
   flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0;
-  margin: 1rem 0;
+  margin: 0;
 }
 
 .skill-badge {
+  position: relative;
   background: var(--btn-bg);
   color: var(--btn-text-color);
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
   font-size: 0.85rem;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.advantages {
-  margin-top: 1rem;
-  padding-left: 1.2rem;
+.skill-badge:hover,
+.skill-badge:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--btn-hover-shadow);
+  outline: none;
 }
 
-.advantages li {
-  margin-bottom: 0.5rem;
+.skill-badge::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  transform: translate(-50%, -4px);
+  background: var(--card-bg);
+  color: var(--text-color);
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0;
+  white-space: nowrap;
+  pointer-events: none;
+  font-size: 0.75rem;
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.skill-badge:hover::after,
+.skill-badge:focus::after {
+  opacity: 1;
+  transform: translate(-50%, -8px);
+}
+
+.projects, .contact {
+  padding: 2rem 0;
+}
+
+@media (min-width: 1024px) {
+  .hero-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 1023px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-about,
+  .reveal-item {
+    transition: none;
+    transform: none;
+  }
 }
 
 .projects-placeholder {
@@ -293,13 +462,4 @@ h1, h2, h3 {
 :focus-visible {
   outline: 2px solid var(--focus-outline);
   outline-offset: 2px;
-}
-
-@media (max-width: 600px) {
-  .hero {
-    padding: 2rem 1rem;
-  }
-  .name {
-    font-size: 2rem;
-  }
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="neon">
+<html lang="en" data-theme="neon" data-decor="on">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -27,7 +27,7 @@
   <nav class="navbar" aria-label="Main navigation">
     <div class="container">
       <ul class="nav-links">
-        <li><a href="#about" class="nav-link" tabindex="0">About</a></li>
+        <li><a href="#hero" class="nav-link" tabindex="0">About</a></li>
         <li><a href="#projects" class="nav-link" tabindex="0">Projects</a></li>
         <li><a href="#contact" class="nav-link" tabindex="0">Contact</a></li>
       </ul>
@@ -40,43 +40,54 @@
     </div>
   </nav>
 
-  <header id="hero" class="hero" tabindex="0">
-    <div class="container hero-content">
-      <img src="assets/avatar.svg" alt="Avatar" class="avatar" loading="lazy" />
-      <h1 class="name">Jack Tan</h1>
-      <p class="title">Software Engineer</p>
-      <p class="location">Penang, Malaysia</p>
-      <p class="intro">Full-stack developer with strong foundation in .NET and web development, passionate about building scalable systems and modern user experiences.</p>
-    </div>
-  </header>
-
-  <section id="about" class="about" tabindex="0">
-    <div class="container about-container">
-      <div class="about-left">
-        <img src="assets/avatar.svg" alt="Jack Tan" class="avatar" loading="lazy" />
+  <section id="hero" class="hero-about" tabindex="0">
+    <div class="glow-divider" aria-hidden="true"></div>
+    <div class="container hero-grid">
+      <div class="hero-left">
+        <img src="assets/avatar.svg" alt="Jack Tan avatar" class="avatar floating" loading="lazy" />
+        <div class="cta-buttons">
+          <a href="assets/resume.pdf" class="btn cta-btn" aria-label="Download resume" tabindex="0">Download Resume</a>
+          <a href="mailto:tanchengyi1997@gmail.com" class="btn cta-btn" aria-label="Email" tabindex="0">Contact</a>
+        </div>
       </div>
-      <div class="about-right">
-        <h2>About</h2>
-        <p>I build scalable web and cloud solutions with a focus on clean architecture and modern user interfaces.</p>
-        <ul class="skills">
-          <li class="skill-badge">C#</li>
-          <li class="skill-badge">.NET Core</li>
-          <li class="skill-badge">ASP.NET MVC &amp; Web API</li>
-          <li class="skill-badge">JavaScript</li>
-          <li class="skill-badge">Vue.js</li>
-          <li class="skill-badge">React</li>
-          <li class="skill-badge">SQL</li>
-          <li class="skill-badge">PostgreSQL</li>
-          <li class="skill-badge">HTML</li>
-          <li class="skill-badge">CSS</li>
-          <li class="skill-badge">Git</li>
-          <li class="skill-badge">Azure</li>
-        </ul>
-        <ul class="advantages">
-          <li>快速学习与适应</li>
-          <li>关注细节与可维护性</li>
-          <li>良好沟通与协作</li>
-        </ul>
+      <div class="hero-right">
+        <h1 class="name reveal-item">Jack Tan</h1>
+        <p class="title reveal-item">Software Engineer</p>
+        <p class="location reveal-item">Penang, Malaysia</p>
+        <p class="intro reveal-item">Full-stack developer with strong foundation in .NET and web development, passionate about building scalable systems and modern user experiences.</p>
+        <div class="highlights">
+          <div class="highlight reveal-item"><span class="count" data-count="4">0</span>+ Years</div>
+          <div class="highlight reveal-item"><span class="count" data-count="10">0</span>+ Projects</div>
+          <div class="highlight reveal-item"><span class="count" data-count="3">0</span> Domains (.NET / Web / Bots)</div>
+        </div>
+        <div class="skill-groups">
+          <div class="skill-group reveal-item">
+            <h3>Backend</h3>
+            <ul class="skills">
+              <li class="skill-badge" data-tooltip="Experienced">C#</li>
+              <li class="skill-badge" data-tooltip="Experienced">.NET Core</li>
+              <li class="skill-badge" data-tooltip="Experienced">ASP.NET MVC &amp; Web API</li>
+              <li class="skill-badge" data-tooltip="Experienced">PostgreSQL</li>
+            </ul>
+          </div>
+          <div class="skill-group reveal-item">
+            <h3>Frontend</h3>
+            <ul class="skills">
+              <li class="skill-badge" data-tooltip="Familiar">JavaScript</li>
+              <li class="skill-badge" data-tooltip="Familiar">Vue.js</li>
+              <li class="skill-badge" data-tooltip="Familiar">React</li>
+              <li class="skill-badge" data-tooltip="Familiar">HTML</li>
+              <li class="skill-badge" data-tooltip="Familiar">CSS</li>
+            </ul>
+          </div>
+          <div class="skill-group reveal-item">
+            <h3>Tools</h3>
+            <ul class="skills">
+              <li class="skill-badge" data-tooltip="Daily">Git</li>
+              <li class="skill-badge" data-tooltip="Regular">Azure</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- merge hero and about sections into a single two-column hero with CTA buttons and grouped skills
- add scroll reveal, floating avatar, counting highlights and responsive layout
- support reduced motion and optional background decoration toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6a419e488324a5ba786d50c854b1